### PR TITLE
Update blueprints.js: add populate as an option

### DIFF
--- a/templates/config/blueprints.js
+++ b/templates/config/blueprints.js
@@ -147,6 +147,17 @@ module.exports.blueprints = {
    * PUT    /foos/:id?
    * DELETE /foos/:id?
    */
-  pluralize: false
+  pluralize: false,
+  
+  /**
+   * `populate`
+   * 
+   * Whether the blueprint controllers should populate model fetches with
+   * data from other models which are linked by associations
+   * 
+   * If you have a lot of data in one-to-many associations, leaving this on
+   * may result in very heavy api calls
+   */
+  populate: true
 
 };


### PR DESCRIPTION
With the new relations in waterline, I think it's really important that users can easily turn off the populate option as ajax api calls can quickly get out-of-hand with big data sets
