### PR TITLE
fix links to documentation

### DIFF
--- a/templates/api/policies/sessionAuth.js
+++ b/templates/api/policies/sessionAuth.js
@@ -4,7 +4,7 @@
  * @module      :: Policy
  * @description :: Simple policy to allow any authenticated user
  *                 Assumes that your login action in one of your controllers sets `req.session.authenticated = true;`
- * @docs        :: http://sailsjs.org/#!documentation/policies
+ * @docs        :: http://sailsjs.org/#!/documentation/policies
  *
  */
 module.exports = function(req, res, next) {

--- a/templates/config/blueprints.js
+++ b/templates/config/blueprints.js
@@ -16,10 +16,10 @@
  * logic in the form of a JSON API, including support for sort, pagination, and filtering.
  *
  * For more information on the blueprint API, check out:
- * http://sailsjs.org/#/documentation/reference/blueprint-api
+ * http://sailsjs.org/#!/documentation/reference/blueprint-api
  *
  * For more information on the settings in this file, see:
- * http://sailsjs.org/#/documentation/reference/sails.config/sails.config.blueprints.html
+ * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.blueprints.html
  *
  */
 

--- a/templates/config/bootstrap.js
+++ b/templates/config/bootstrap.js
@@ -6,7 +6,7 @@
  * This gives you an opportunity to set up your data model, run jobs, or perform some special logic.
  *
  * For more information on bootstrapping your app, check out:
- * http://sailsjs.org/#/documentation/reference/sails.config/sails.config.bootstrap.html
+ * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.bootstrap.html
  */
 
 module.exports.bootstrap = function(cb) {

--- a/templates/config/connections.js
+++ b/templates/config/connections.js
@@ -16,7 +16,7 @@
  * (this is to prevent you inadvertently sensitive credentials up to your repository.)
  *
  * For more information on configuration, check out:
- * http://sailsjs.org/#/documentation/reference/sails.config/sails.config.connections.html
+ * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.connections.html
  */
 
 module.exports.connections = {

--- a/templates/config/cors.js
+++ b/templates/config/cors.js
@@ -22,7 +22,7 @@
  *  }
  *
  *  For more information on this configuration file, see:
- *  http://sailsjs.org/#/documentation/reference/sails.config/sails.config.cors.html
+ *  http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.cors.html
  *
  */
 

--- a/templates/config/csrf.js
+++ b/templates/config/csrf.js
@@ -38,7 +38,7 @@
  * http://en.wikipedia.org/wiki/Cross-site_request_forgery
  *
  * For more information on this configuration file, including info on CSRF + CORS, see:
- * http://beta.sailsjs.org/#/documentation/reference/sails.config/sails.config.csrf.html
+ * http://beta.sailsjs.org/#!/documentation/reference/sails.config/sails.config.csrf.html
  *
  */
 

--- a/templates/config/globals.js
+++ b/templates/config/globals.js
@@ -6,7 +6,7 @@
  * automatically by Sails.
  *
  * For more information on configuration, check out:
- * http://sailsjs.org/#/documentation/reference/sails.config/sails.config.globals.html
+ * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.globals.html
  */
 module.exports.globals = {
 

--- a/templates/config/http.js
+++ b/templates/config/http.js
@@ -6,7 +6,7 @@
  * Only applies to HTTP requests (not WebSockets)
  *
  * For more information on configuration, check out:
- * http://sailsjs.org/#/documentation/reference/sails.config/sails.config.http.html
+ * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.http.html
  */
 
 module.exports.http = {

--- a/templates/config/i18n.js
+++ b/templates/config/i18n.js
@@ -7,7 +7,7 @@
  *
  *
  * For more informationom i18n in Sails, check out:
- * http://sailsjs.org/#/documentation/concepts/Internationalization
+ * http://sailsjs.org/#!/documentation/concepts/Internationalization
  *
  * For a complete list of i18n options, see:
  * https://github.com/mashpie/i18n-node#list-of-configuration-options

--- a/templates/config/local.js
+++ b/templates/config/local.js
@@ -24,7 +24,7 @@
  *
  *
  * For more information, check out:
- * http://sailsjs.org/#/documentation/reference/sails.config/sails.config.local.html
+ * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.local.html
  */
 
 module.exports = {

--- a/templates/config/log.js
+++ b/templates/config/log.js
@@ -7,7 +7,7 @@
  * allows for some pretty neat custom transports/adapters for log messages)
  *
  * For more information on the Sails logger, check out:
- * http://sailsjs.org/#/documentation/concepts/Logging
+ * http://sailsjs.org/#!/documentation/concepts/Logging
  */
 
 module.exports.log = {

--- a/templates/config/models.js
+++ b/templates/config/models.js
@@ -6,7 +6,7 @@
  * in each of your models.
  *
  * For more info on Sails models, see:
- * http://sailsjs.org/#/documentation/concepts/ORM
+ * http://sailsjs.org/#!/documentation/concepts/ORM
  */
 
 module.exports.models = {
@@ -24,7 +24,7 @@ module.exports.models = {
   * How and whether Sails will attempt to automatically rebuild the          *
   * tables/collections/etc. in your schema.                                  *
   *                                                                          *
-  * See http://sailsjs.org/#/documentation/concepts/ORM/model-settings.html  *
+  * See http://sailsjs.org/#!/documentation/concepts/ORM/model-settings.html  *
   *                                                                          *
   ***************************************************************************/
   // migrate: 'alter'

--- a/templates/config/policies.js
+++ b/templates/config/policies.js
@@ -10,10 +10,10 @@
  * below by its filename, minus the extension, (e.g. "authenticated")
  *
  * For more information on how policies work, see:
- * http://sailsjs.org/#/documentation/concepts/Policies
+ * http://sailsjs.org/#!/documentation/concepts/Policies
  *
  * For more information on configuring policies, check out:
- * http://sailsjs.org/#/documentation/reference/sails.config/sails.config.policies.html
+ * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.policies.html
  */
 
 

--- a/templates/config/routes.js
+++ b/templates/config/routes.js
@@ -17,7 +17,7 @@
  * CoffeeScript for the front-end.
  *
  * For more information on configuring custom routes, check out:
- * http://sailsjs.org/#/documentation/concepts/Routes/RouteTargetSyntax.html
+ * http://sailsjs.org/#!/documentation/concepts/Routes/RouteTargetSyntax.html
  */
 
 module.exports.routes = {

--- a/templates/config/session.js
+++ b/templates/config/session.js
@@ -9,7 +9,7 @@
  * and auto-save to `req.session` with Socket.io the same way you would with Express.
  *
  * For more information on configuring the session, check out:
- * http://sailsjs.org/#/documentation/reference/sails.config/sails.config.session.html
+ * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.session.html
  */
 
 module.exports.session = {

--- a/templates/config/sockets.js
+++ b/templates/config/sockets.js
@@ -7,7 +7,7 @@
  * configuration layered on top.
  *
  * For more information on sockets configuration, including advanced config options, see:
- * http://sailsjs.org/#/documentation/reference/sails.config/sails.config.sockets.html
+ * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.sockets.html
  */
 
 module.exports.sockets = {

--- a/templates/config/views.js
+++ b/templates/config/views.js
@@ -8,7 +8,7 @@
  * Sails' layout support.
  *
  * For more information on views and layouts, check out:
- * http://sailsjs.org/#/documentation/concepts/Views
+ * http://sailsjs.org/#!/documentation/concepts/Views
  */
 
 module.exports.views = {


### PR DESCRIPTION
All documentation links were broken. This commit simply adds a bang to the URL to match the doc site.
`#  =>  #!`