### PR TITLE
Update before.js

### DIFF
--- a/lib/before.js
+++ b/lib/before.js
@@ -49,7 +49,7 @@ module.exports = function(scope, cb) {
 
 		// enable partials and layout for handlebars
 		if (scope.viewEngine === 'handlebars') {
-			scope.layout = 'layouts/layout.handlebars';
+			scope.layout = 'layouts/layout';
 			scope.partials = 'partials';
 		}
 	} 


### PR DESCRIPTION
Removed the ".handlebars" extension in the scope.layout string on line 52.  Otherwise, the example app main view is broken from the start because the route is loaded as "layout.handlebars.handlebars".