### PR TITLE
add coffee-script generation with a --coffee option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ $ npm install sails-generate-backend
 ##### On the command line
 
 ```sh
-$ sails generate backend 
+$ sails generate backend [--coffee]
 ```
+
+If the coffee option is used, the generator will generate coffeescript files instead of javascript files.
 
 ##### In a node script
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ node ./bin
 
 `bin/index.js` is a simple script, bundled only for convenience, that runs the generator with hard-coded scope variables.  Please feel free to modify that file however you like!  Also see `CONTRIBUTING.md` for more information on overriding/enhancing generators.
 
-
+Tests must pass with `npm run test` for any modification.
 
 ### Questions?
 

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,114 @@
+{
+  "coffeescript_error": {
+    "level": "error"
+  },
+  "arrow_spacing": {
+    "name": "arrow_spacing",
+    "level": "warn"
+  },
+  "no_tabs": {
+    "name": "no_tabs",
+    "level": "error"
+  },
+  "no_trailing_whitespace": {
+    "name": "no_trailing_whitespace",
+    "level": "warn",
+    "allowed_in_comments": false,
+    "allowed_in_empty_lines": true
+  },
+  "max_line_length": {
+    "name": "max_line_length",
+    "value": 80,
+    "level": "warn",
+    "limitComments": true
+  },
+  "line_endings": {
+    "name": "line_endings",
+    "level": "ignore",
+    "value": "unix"
+  },
+  "no_trailing_semicolons": {
+    "name": "no_trailing_semicolons",
+    "level": "error"
+  },
+  "indentation": {
+    "name": "indentation",
+    "value": 2,
+    "level": "error"
+  },
+  "camel_case_classes": {
+    "name": "camel_case_classes",
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "name": "colon_assignment_spacing",
+    "level": "warn",
+    "spacing": {
+      "left": 0,
+      "right": 1
+    }
+  },
+  "no_implicit_braces": {
+    "name": "no_implicit_braces",
+    "level": "ignore",
+    "strict": true
+  },
+  "no_plusplus": {
+    "name": "no_plusplus",
+    "level": "ignore"
+  },
+  "no_throwing_strings": {
+    "name": "no_throwing_strings",
+    "level": "error"
+  },
+  "no_backticks": {
+    "name": "no_backticks",
+    "level": "error"
+  },
+  "no_implicit_parens": {
+    "name": "no_implicit_parens",
+    "level": "ignore"
+  },
+  "no_empty_param_list": {
+    "name": "no_empty_param_list",
+    "level": "warn"
+  },
+  "no_stand_alone_at": {
+    "name": "no_stand_alone_at",
+    "level": "ignore"
+  },
+  "space_operators": {
+    "name": "space_operators",
+    "level": "warn"
+  },
+  "duplicate_key": {
+    "name": "duplicate_key",
+    "level": "error"
+  },
+  "empty_constructor_needs_parens": {
+    "name": "empty_constructor_needs_parens",
+    "level": "ignore"
+  },
+  "cyclomatic_complexity": {
+    "name": "cyclomatic_complexity",
+    "value": 10,
+    "level": "ignore"
+  },
+  "newlines_after_classes": {
+    "name": "newlines_after_classes",
+    "value": 3,
+    "level": "ignore"
+  },
+  "no_unnecessary_fat_arrows": {
+    "name": "no_unnecessary_fat_arrows",
+    "level": "warn"
+  },
+  "missing_fat_arrows": {
+    "name": "missing_fat_arrows",
+    "level": "ignore"
+  },
+  "non_empty_constructor_needs_parens": {
+    "name": "non_empty_constructor_needs_parens",
+    "level": "ignore"
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@
  *
  * @type {Object}
  */
+var targets = require('./targets');
+var coffeeTemplate = process.argv.indexOf('--coffee') !== -1;
 
 module.exports = {
 
@@ -13,58 +15,5 @@ module.exports = {
 
   before: require('./before'),
 
-  targets: {
-
-    '.': ['views'],
-    './api/controllers': { folder: {}},
-    './api/models': { folder: {}},
-    './api/policies': { folder: {}},
-    './api/services': { folder: {}},
-    './api/responses': { folder: {}},
-
-    './api/controllers/.gitkeep': { copy: '.gitkeep'},
-    './api/models/.gitkeep': { copy: '.gitkeep'},
-    './api/services/.gitkeep': { copy: '.gitkeep'},
-    './config/connections.js': { copy: 'config/connections.js' },
-    './config/models.js': { copy: 'config/models.js' },
-    './config/blueprints.js': { copy: 'config/blueprints.js' },
-    './config/bootstrap.js': { copy: 'config/bootstrap.js' },
-    './config/cors.js': { copy: 'config/cors.js' },
-    './config/csrf.js': { copy: 'config/csrf.js' },
-    './config/http.js': { copy: 'config/http.js' },
-    './config/globals.js': { copy: 'config/globals.js' },
-    './config/i18n.js': { copy: 'config/i18n.js' },
-    './config/local.js': { copy: 'config/local.js' },
-    './config/log.js': { copy: 'config/log.js' },
-    './config/policies.js': { copy: 'config/policies.js' },
-    './config/routes.js': { copy: 'config/routes.js' },
-    './config/sockets.js': { copy: 'config/sockets.js' },
-
-    './config/session.js': { template: 'config/session.js' },
-    './config/views.js': { template: 'config/views.js' },
-
-    './config/locales/de.json': { copy: 'config/locales/de.json' },
-    './config/locales/en.json': { copy: 'config/locales/en.json' },
-    './config/locales/es.json': { copy: 'config/locales/es.json' },
-    './config/locales/fr.json': { copy: 'config/locales/fr.json' },
-    './config/locales/_README.md': { copy: 'config/locales/_README.md' },
-
-    './config/env/production.js': { copy: 'config/env/production.js' },
-    './config/env/development.js': { copy: 'config/env/development.js' },
-
-    './api/policies/sessionAuth.js': { copy: 'api/policies/sessionAuth.js' },
-
-    './api/responses/badRequest.js': { copy: 'api/responses/badRequest.js' },
-    './api/responses/forbidden.js': { copy: 'api/responses/forbidden.js' },
-    './api/responses/notFound.js': { copy: 'api/responses/notFound.js' },
-    './api/responses/serverError.js': { copy: 'api/responses/serverError.js' },
-    './api/responses/ok.js': { copy: 'api/responses/ok.js' },
-
-    // Excluding `res.negotiate()` from the generated files for now,
-    // since it's best if its definition is consistent between projects.
-    // It can still be overridden by creating api/responses/negotiate.js.
-    // './api/responses/negotiate.js': { copy: 'api/responses/negotiate.js' },
-
-  }
+  targets: targets.buildTargets(targets.templateFiles, coffeeTemplate)
 };
-

--- a/lib/targets.js
+++ b/lib/targets.js
@@ -1,0 +1,131 @@
+var templateFiles = {
+  views: '.',
+  folder: [
+    'api/controllers',
+    'api/models',
+    'api/policies',
+    'api/services',
+    'api/responses'
+  ],
+  copy: [
+    'api/controllers/.gitkeep',
+    'api/models/.gitkeep',
+    'api/services/.gitkeep',
+    'config/locales/de.json',
+    'config/locales/en.json',
+    'config/locales/es.json',
+    'config/locales/fr.json',
+    'config/locales/_README.md',
+    'config/connections.js',
+    'config/models.js',
+    'config/blueprints.js',
+    'config/bootstrap.js',
+    'config/cors.js',
+    'config/csrf.js',
+    'config/http.js',
+    'config/globals.js',
+    'config/i18n.js',
+    'config/local.js',
+    'config/log.js',
+    'config/policies.js',
+    'config/routes.js',
+    'config/sockets.js',
+    'config/env/production.js',
+    'config/env/development.js',
+    'api/policies/sessionAuth.js',
+    'api/responses/badRequest.js',
+    'api/responses/forbidden.js',
+    'api/responses/notFound.js',
+    'api/responses/serverError.js',
+    'api/responses/ok.js'
+  ],
+  template: [
+    'config/session.js',
+    'config/views.js'
+  ]
+};
+
+/**
+ * Build a formatted targets object
+ *
+ * @param templateFiles   {Object} - Contains template files
+ * @param coffeeTemplate {Boolean} - Generate the coffee files if true
+ *
+ * For this given object:
+ * {
+ *   views: '.',
+ *   folder: [
+ *     'api/controllers'
+ *   ],
+ *   copy: [
+ *     'api/controllers/.gitkeep',
+ *     'config/locales/de.json',
+ *     'config/locales/_README.md',
+ *     'config/connections.js'
+ *   ],
+ *   template: [
+ *     'config/session.js'
+ *   ]
+ * }
+ * will be returned ():
+ * {
+ *   '.'                         : ['views'],
+ *   './api/controllers'         : { folder: {} },
+ *   './api/controllers/.gitkeep': { copy: '.gitkeep' },
+ *   './config/locales/de.json'  : { copy: 'config/locales/de.json' },
+ *   './config/locales/_README.md': { copy: 'config/locales/_README.md' },
+ *   './config/connections.js'   : { copy: 'config/connections.js' },
+ *   './config/session.js'       : { template: 'config/session.js' }
+ * }
+ *
+ * @returns {Object}
+ */
+function buildTargets(templateFiles, coffeeTemplate) {
+  var targets = {};
+  var type;
+  var destination;
+  var filesName;
+  var isGitkeepFile;
+  var filePath;
+  var path;
+
+  for (type in templateFiles) {
+
+    if (type === 'views') {
+      destination = templateFiles[type];
+      targets[destination] = [ type ];
+      continue;
+    }
+
+    filesName = templateFiles[type];
+
+    filesName.forEach(function (fileName) {
+      filePath = fileName;
+      path = {};
+
+      if (type !== 'folder') {
+        isGitkeepFile = fileName.indexOf('.gitkeep') !== -1;
+
+        if (isGitkeepFile) {
+          path = '.gitkeep';
+        }
+        else {
+          if (coffeeTemplate) {
+            filePath = filePath.replace(/.js$/, '.coffee')
+          }
+
+          path = filePath;
+        }
+      }
+
+      destination = './' + filePath;
+      targets[destination] = {};
+      targets[destination][type] = path;
+    });
+  }
+
+  return targets;
+}
+
+exports.templateFiles = templateFiles;
+exports.buildTargets = buildTargets;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "sails-generate": "*",
     "coffeelint": "^1.10.1",
+    "mocha": "^2.2.5",
     "reportback": "*",
     "fs-extra": "*"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-generate-backend",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "Generate a backend for Sails.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "sails-generate": "*",
+    "coffeelint": "^1.10.1",
     "reportback": "*",
     "fs-extra": "*"
   },

--- a/templates/api/policies/sessionAuth.coffee
+++ b/templates/api/policies/sessionAuth.coffee
@@ -1,0 +1,19 @@
+###
+# sessionAuth
+#
+# @module      :: Policy
+# @description :: Simple policy to allow any authenticated user
+#                 Assumes that your login action in one of your controllers
+#                 sets `req.session.authenticated = true;`
+# @docs        :: http://sailsjs.org/#!/documentation/concepts/Policies
+#
+###
+module.exports = (req, res, next) ->
+
+# User is allowed, proceed to the next policy,
+# or if this is the last policy, the controller
+  return next() if req.session.authenticated?
+
+  # User is not allowed
+  # (default res.forbidden() behavior can be overridden in `config/403.js`)
+  res.forbidden 'You are not permitted to perform this action.'

--- a/templates/api/responses/badRequest.coffee
+++ b/templates/api/responses/badRequest.coffee
@@ -1,0 +1,52 @@
+###
+# 400 (Bad Request) Handler
+#
+# Usage:
+# return res.badRequest();
+# return res.badRequest(data);
+# return res.badRequest(data, 'some/specific/badRequest/view');
+#
+# e.g.:
+# ```
+# return res.badRequest(
+#   'Please choose a valid `password` (6-12 characters)',
+#   'trial/signup'
+# );
+# ```
+###
+module.exports = (data, options = {}) ->
+
+# Get access to `req`, `res`, & `sails`
+  req = @req
+  res = @res
+  sails = req._sails
+
+  # Set status code
+  res.status 400
+
+  # Log error to console
+  if data?
+    sails.log.verbose 'Sending 400 ("Bad Request") response: \n', data
+  else
+    sails.log.verbose 'Sending 400 ("Bad Request") response'
+
+  # Only include errors in response if application environment
+  # is not set to 'production'.  In production, we shouldn't
+  # send back any identifying information about errors.
+  data = undefined if sails.config.environment == 'production'
+
+  # If the user-agent wants JSON, always respond with JSON
+  return res.jsonx(data) if req.wantsJSON?
+
+  # If second argument is a string, we take that to mean it refers to a view.
+  # If it was omitted, use an empty object (`{}`)
+  options = view: options if typeof options == 'string'
+
+  # If a view was provided in options, serve it.
+  # Otherwise try to guess an appropriate view, or if that doesn't
+  # work, just send JSON.
+
+  return res.view options.view, data: data if options.view?
+
+  res.guessView data: data, ->
+    res.jsonx data

--- a/templates/api/responses/forbidden.coffee
+++ b/templates/api/responses/forbidden.coffee
@@ -1,0 +1,62 @@
+###
+# 403 (Forbidden) Handler
+#
+# Usage:
+# return res.forbidden();
+# return res.forbidden(err);
+# return res.forbidden(err, 'some/specific/forbidden/view');
+#
+# e.g.:
+# ```
+# return res.forbidden('Access denied.');
+# ```
+###
+module.exports = (data, options = {}) ->
+
+  # Get access to `req`, `res`, & `sails`
+  req = @req
+  res = @res
+  sails = req._sails
+
+  # Set status code
+  res.status 403
+
+  # Log error to console
+  if data?
+    sails.log.verbose 'Sending 403 ("Forbidden") response: \n', data
+  else
+    sails.log.verbose 'Sending 403 ("Forbidden") response'
+
+  # Only include errors in response if application environment
+  # is not set to 'production'.  In production, we shouldn't
+  # send back any identifying information about errors.
+
+  data = undefined if sails.config.environment == 'production'
+
+  # If the user-agent wants JSON, always respond with JSON
+  return res.jsonx(data) if req.wantsJSON?
+
+  # If second argument is a string, we take that to mean it refers to a view.
+  # If it was omitted, use an empty object (`{}`)
+  options = view: options if typeof options == 'string'
+
+  # If a view was provided in options, serve it.
+  # Otherwise try to guess an appropriate view, or if that doesn't
+  # work, just send JSON.
+  return res.view options.view, data: data if options.view?
+
+  res.view '403', data: data, (err, html) ->
+    # If a view error occured, fall back to JSON(P).
+    if err
+      # Additionally:
+      # • If the view was missing, ignore the error but provide a verbose log.
+      if err.code == 'E_VIEW_FAILED'
+        sails.log.verbose 'res.forbidden() :: Could not locate view
+          for error page (sending JSON instead).  Details: ', err
+      else
+        sails.log.warn 'res.forbidden() :: When attempting to render error
+          page view, an error occured (sending JSON instead).  Details: ', err
+
+      return res.jsonx(data)
+
+    res.send html

--- a/templates/api/responses/notFound.coffee
+++ b/templates/api/responses/notFound.coffee
@@ -1,0 +1,66 @@
+###
+# 404 (Not Found) Handler
+#
+# Usage:
+# return res.notFound();
+# return res.notFound(err);
+# return res.notFound(err, 'some/specific/notfound/view');
+#
+# e.g.:
+# ```
+# return res.notFound();
+# ```
+#
+# NOTE:
+# If a request doesn't match any explicit routes (i.e. `config/routes.js`)
+# or route blueprints (i.e. "shadow routes", Sails will call `res.notFound()`
+# automatically.
+###
+module.exports = (data, options = {}) ->
+
+# Get access to `req`, `res`, & `sails`
+  req = @req
+  res = @res
+  sails = req._sails
+
+  # Set status code
+  res.status 404
+
+  # Log error to console
+  if data?
+    sails.log.verbose 'Sending 404 ("Not Found") response: \n', data
+  else
+    sails.log.verbose 'Sending 404 ("Not Found") response'
+
+  # Only include errors in response if application environment
+  # is not set to 'production'.  In production, we shouldn't
+  # send back any identifying information about errors.
+  data = undefined if sails.config.environment == 'production'
+
+  # If the user-agent wants JSON, always respond with JSON
+  return res.jsonx(data) if req.wantsJSON?
+
+  # If second argument is a string, we take that to mean it refers to a view.
+  # If it was omitted, use an empty object (`{}`)
+  options = view: options if typeof options == 'string'
+
+  # If a view was provided in options, serve it.
+  # Otherwise try to guess an appropriate view, or if that doesn't
+  # work, just send JSON.
+  return res.view options.view, data: data if options.view?
+
+  res.view '404', data: data, (err, html) ->
+    # If a view error occured, fall back to JSON(P).
+    if err
+      # Additionally:
+      # • If the view was missing, ignore the error but provide a verbose log.
+      if err.code == 'E_VIEW_FAILED'
+        sails.log.verbose 'res.notFound() :: Could not locate view
+          for error page (sending JSON instead).  Details: ', err
+      else
+        sails.log.warn 'res.notFound() :: When attempting to render error page
+          view, an error occured (sending JSON instead).  Details: ', err
+
+      return res.jsonx(data)
+
+    res.send html

--- a/templates/api/responses/ok.coffee
+++ b/templates/api/responses/ok.coffee
@@ -1,0 +1,38 @@
+###
+# 200 (OK) Response
+#
+# Usage:
+# return res.ok();
+# return res.ok(data);
+# return res.ok(data, 'auth/login');
+#
+# @param  {Object} data
+# @param  {String|Object} options
+#          - pass string to render specified view
+###
+module.exports = (data, options = {}) ->
+
+  # Get access to `req`, `res`, & `sails`
+  req = @req
+  res = @res
+  sails = req._sails
+  sails.log.silly 'res.ok() :: Sending 200 ("OK") response'
+
+  # Set status code
+  res.status 200
+
+  # If appropriate, serve data as JSON(P)
+  return res.jsonx(data) if req.wantsJSON?
+
+  # If second argument is a string, we take that to mean it refers to a view.
+  # If it was omitted, use an empty object (`{}`)
+  options = view: options if typeof options == 'string'
+
+  # If a view was provided in options, serve it.
+  # Otherwise try to guess an appropriate view, or if that doesn't
+  # work, just send JSON.
+
+  return res.view options.view, data: data if options.view
+
+  res.guessView data: data, ->
+    res.jsonx data

--- a/templates/api/responses/serverError.coffee
+++ b/templates/api/responses/serverError.coffee
@@ -1,0 +1,62 @@
+###
+# 500 (Server Error) Response
+#
+# Usage:
+# return res.serverError();
+# return res.serverError(err);
+# return res.serverError(err, 'some/specific/error/view');
+#
+# NOTE:
+# If something throws in a policy or controller, or an internal
+# error is encountered, Sails will call `res.serverError()`
+# automatically.
+###
+module.exports = (data, options = {}) ->
+
+  # Get access to `req`, `res`, & `sails`
+  req = @req
+  res = @res
+  sails = req._sails
+
+  # Set status code
+  res.status 500
+
+  # Log error to console
+  if data?
+    sails.log.error 'Sending 500 ("Server Error") response: \n', data
+  else
+    sails.log.error 'Sending empty 500 ("Server Error") response'
+
+  # Only include errors in response if application environment
+  # is not set to 'production'.  In production, we shouldn't
+  # send back any identifying information about errors.
+  data = undefined if sails.config.environment == 'production'
+
+  # If the user-agent wants JSON, always respond with JSON
+  return res.jsonx(data) if req.wantsJSON?
+
+  # If second argument is a string, we take that to mean it refers to a view.
+  # If it was omitted, use an empty object (`{}`)
+  options = view: options if typeof options == 'string'
+
+  # If a view was provided in options, serve it.
+  # Otherwise try to guess an appropriate view, or if that doesn't
+  # work, just send JSON.
+
+  return res.view options.view, data: data if options.view?
+
+  res.view '500', data: data, (err, html) ->
+    # If a view error occured, fall back to JSON(P).
+    if err
+      # Additionally:
+      # • If the view was missing, ignore the error but provide a verbose log.
+      if err.code == 'E_VIEW_FAILED'
+        sails.log.verbose 'res.serverError() :: Could not locate view
+          for error page (sending JSON instead).  Details: ', err
+      else
+        sails.log.warn 'res.serverError() :: When attempting to render error
+          page view, an error occured (sending JSON instead).  Details: ', err
+
+      return res.jsonx(data)
+
+    res.send html

--- a/templates/config/blueprints.coffee
+++ b/templates/config/blueprints.coffee
@@ -1,0 +1,161 @@
+###
+# Blueprint API Configuration
+# (sails.config.blueprints)
+#
+# These settings are for the global configuration of blueprint routes and
+# request options (which impact the behavior of blueprint actions).
+#
+# You may also override any of these settings on a per-controller basis
+# by defining a '_config' key in your controller definition, and assigning it
+# a configuration object with overrides for the settings in this file.
+# A lot of the configuration options below affect so-called "CRUD methods",
+# or your controllers' `find`, `create`, `update`, and `destroy` actions.
+#
+# It's important to realize that, even if you haven't defined these yourself, as long as
+# a model exists with the same name as the controller, Sails will respond with built-in CRUD
+# logic in the form of a JSON API, including support for sort, pagination, and filtering.
+#
+# For more information on the blueprint API, check out:
+# http://sailsjs.org/#!/documentation/reference/blueprint-api
+#
+# For more information on the settings in this file, see:
+# http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.blueprints.html
+#
+###
+
+module.exports.blueprints = {
+
+  ############################################################################
+  #                                                                          #
+  # Action routes speed up the backend development workflow by               #
+  # eliminating the need to manually bind routes. When enabled, GET, POST,   #
+  # PUT, and DELETE routes will be generated for every one of a controller's #
+  # actions.                                                                 #
+  #                                                                          #
+  # If an `index` action exists, additional naked routes will be created for #
+  # it. Finally, all `actions` blueprints support an optional path           #
+  # parameter, `id`, for convenience.                                        #
+  #                                                                          #
+  # `actions` are enabled by default, and can be OK for production--         #
+  # however, if you'd like to continue to use controller/action autorouting  #
+  # in a production deployment, you must take great care not to              #
+  # inadvertently expose unsafe/unintentional controller logic to GET        #
+  # requests.                                                                #
+  #                                                                          #
+  ############################################################################
+
+  # actions: true
+
+  ############################################################################
+  #                                                                          #
+  # RESTful routes (`sails.config.blueprints.rest`)                          #
+  #                                                                          #
+  # REST blueprints are the automatically generated routes Sails uses to     #
+  # expose a conventional REST API on top of a controller's `find`,          #
+  # `create`, `update`, and `destroy` actions.                               #
+  #                                                                          #
+  # For example, a BoatController with `rest` enabled generates the          #
+  # following routes:                                                        #
+  # :::::::::::::::::::::::::::::::::::::::::::::::::::::::                  #
+  #  GET /boat -> BoatController.find                                        #
+  #  GET /boat/:id -> BoatController.findOne                                 #
+  #  POST /boat -> BoatController.create                                     #
+  #  PUT /boat/:id -> BoatController.update                                  #
+  #  DELETE /boat/:id -> BoatController.destroy                              #
+  #                                                                          #
+  # `rest` blueprint routes are enabled by default, and are suitable for use #
+  # in a production scenario, as long you take standard security precautions #
+  # (combine w/ policies, etc.)                                              #
+  #                                                                          #
+  ############################################################################
+
+  # rest: true
+
+  ############################################################################
+  #                                                                          #
+  # Shortcut routes are simple helpers to provide access to a                #
+  # controller's CRUD methods from your browser's URL bar. When enabled,     #
+  # GET, POST, PUT, and DELETE routes will be generated for the              #
+  # controller's`find`, `create`, `update`, and `destroy` actions.           #
+  #                                                                          #
+  # `shortcuts` are enabled by default, but should be disabled in            #
+  # production.                                                              #
+  #                                                                          #
+  ############################################################################
+
+  # shortcuts: true
+
+  ############################################################################
+  #                                                                          #
+  # An optional mount path for all blueprint routes on a controller,         #
+  # including `rest`, `actions`, and `shortcuts`. This allows you to take    #
+  # advantage of blueprint routing, even if you need to namespace your API   #
+  # methods.                                                                 #
+  #                                                                          #
+  # (NOTE: This only applies to blueprint autoroutes, not manual routes from #
+  # `sails.config.routes`)                                                   #
+  #                                                                          #
+  ############################################################################
+
+  # prefix: ''
+
+  ############################################################################
+  #                                                                          #
+  # An optional mount path for all REST blueprint routes on a controller.    #
+  # And it do not include `actions` and `shortcuts` routes.                  #
+  # This allows you to take advantage of REST blueprint routing,             #
+  # even if you need to namespace your RESTful API methods                   #
+  #                                                                          #
+  ############################################################################
+
+  # restPrefix: ''
+
+  ############################################################################
+  #                                                                          #
+  # Whether to pluralize controller names in blueprint routes.               #
+  #                                                                          #
+  # (NOTE: This only applies to blueprint autoroutes, not manual routes from #
+  # `sails.config.routes`)                                                   #
+  #                                                                          #
+  # For example, REST blueprints for `FooController` with `pluralize`        #
+  # enabled:                                                                 #
+  # GET /foos/:id?                                                           #
+  # POST /foos                                                               #
+  # PUT /foos/:id?                                                           #
+  # DELETE /foos/:id?                                                        #
+  #                                                                          #
+  ############################################################################
+
+  # pluralize: false
+
+  ############################################################################
+  #                                                                          #
+  # Whether the blueprint controllers should populate model fetches with     #
+  # data from other models which are linked by associations                  #
+  #                                                                          #
+  # If you have a lot of data in one-to-many associations, leaving this on   #
+  # may result in very heavy api calls                                       #
+  #                                                                          #
+  ############################################################################
+
+  # populate: true
+
+  #############################################################################
+  #                                                                           #
+  # Whether to run Model.watch() in the find and findOne blueprint actions.   #
+  # Can be overridden on a per-model basis.                                   #
+  #                                                                           #
+  #############################################################################
+
+  # autoWatch: true
+
+  #############################################################################
+  #                                                                           #
+  # The default number of records to show in the response from a "find"       #
+  # action. Doubles as the default size of populated arrays if populate is    #
+  # true.                                                                     #
+  #                                                                           #
+  #############################################################################
+
+  # defaultLimit: 30
+}

--- a/templates/config/bootstrap.coffee
+++ b/templates/config/bootstrap.coffee
@@ -1,0 +1,16 @@
+###
+# Bootstrap
+# (sails.config.bootstrap)
+#
+# An asynchronous bootstrap function that runs before your Sails app gets lifted.
+# This gives you an opportunity to set up your data model, run jobs, or perform some special logic.
+#
+# For more information on bootstrapping your app, check out:
+# http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.bootstrap.html
+###
+
+module.exports.bootstrap = (cb) ->
+
+  # It's very important to trigger this callback method when you are finished
+  # with the bootstrap!  (otherwise your server will never lift, since it's waiting on the bootstrap)
+  cb()

--- a/templates/config/connections.coffee
+++ b/templates/config/connections.coffee
@@ -1,0 +1,84 @@
+###
+# Connections
+# (sails.config.connections)
+#
+# `Connections` are like "saved settings" for your adapters.  What's the difference between
+# a connection and an adapter, you might ask?  An adapter (e.g. `sails-mysql`) is generic--
+# it needs some additional information to work (e.g. your database host, password, user, etc.)
+# A `connection` is that additional information.
+#
+# Each model must have a `connection` property (a string) which is references the name of one
+# of these connections.  If it doesn't, the default `connection` configured in `config/models.js`
+# will be applied.  Of course, a connection can (and usually is) shared by multiple models.
+# .
+# Note: If you're using version control, you should put your passwords/api keys
+# in `config/local.js`, environment variables, or use another strategy.
+# (this is to prevent you inadvertently sensitive credentials up to your repository.)
+#
+# For more information on configuration, check out:
+# http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.connections.html
+###
+
+module.exports.connections =
+
+  ############################################################################
+  #                                                                          #
+  # Local disk storage for DEVELOPMENT ONLY                                  #
+  #                                                                          #
+  # Installed by default.                                                    #
+  #                                                                          #
+  ############################################################################
+  localDiskDb:
+    adapter: "sails-disk"
+
+  ############################################################################
+  #                                                                          #
+  # MySQL is the world's most popular relational database.                   #
+  # http://en.wikipedia.org/wiki/MySQL                                       #
+  #                                                                          #
+  # Run: npm install sails-mysql                                             #
+  #                                                                          #
+  ############################################################################
+  someMysqlServer:
+    adapter: "sails-mysql"
+    host: "YOUR_MYSQL_SERVER_HOSTNAME_OR_IP_ADDRESS"
+    user: "YOUR_MYSQL_USER"
+    password: "YOUR_MYSQL_PASSWORD"
+    database: "YOUR_MYSQL_DB"
+
+  ############################################################################
+  #                                                                          #
+  # MongoDB is the leading NoSQL database.                                   #
+  # http://en.wikipedia.org/wiki/MongoDB                                     #
+  #                                                                          #
+  # Run: npm install sails-mongo                                             #
+  #                                                                          #
+  ############################################################################
+  someMongodbServer:
+    adapter: "sails-mongo"
+    host: "localhost"
+    port: 27017
+    # user: 'username',
+    # password: 'password',
+    # database: 'your_mongo_db_name_here'
+
+  ############################################################################
+  #                                                                          #
+  # PostgreSQL is another officially supported relational database.          #
+  # http://en.wikipedia.org/wiki/PostgreSQL                                  #
+  #                                                                          #
+  # Run: npm install sails-postgresql                                        #
+  #                                                                          #
+  ############################################################################
+  somePostgresqlServer:
+    adapter: "sails-postgresql"
+    host: "YOUR_POSTGRES_SERVER_HOSTNAME_OR_IP_ADDRESS"
+    user: "YOUR_POSTGRES_USER"
+    password: "YOUR_POSTGRES_PASSWORD"
+    database: "YOUR_POSTGRES_DB"
+
+  ############################################################################
+  #                                                                          #
+  # More adapters: https://github.com/balderdashy/sails                      #
+  #                                                                          #
+  ############################################################################

--- a/templates/config/cors.coffee
+++ b/templates/config/cors.coffee
@@ -1,0 +1,78 @@
+###
+# Cross-Origin Resource Sharing (CORS) Settings
+# (sails.config.cors)
+#
+# CORS is like a more modern version of JSONP-- it allows your server/API
+# to successfully respond to requests from client-side JavaScript code
+# running on some other domain (e.g. google.com)
+# Unlike JSONP, it works with POST, PUT, and DELETE requests
+#
+# For more information on CORS, check out:
+# http://en.wikipedia.org/wiki/Cross-origin_resource_sharing
+#
+# Note that any of these settings (besides 'allRoutes') can be changed on a per-route basis
+# by adding a "cors" object to the route configuration:
+#
+# '/get foo': {
+#   controller: 'foo',
+#   action: 'bar',
+#   cors: {
+#     origin: 'http://foobar.com,https://owlhoot.com'
+#   }
+#  }
+#
+#  For more information on this configuration file, see:
+#  http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.cors.html
+#
+###
+
+module.exports.cors = {
+
+  ############################################################################
+  #                                                                          #
+  # Allow CORS on all routes by default? If not, you must enable CORS on a   #
+  # per-route basis by either adding a "cors" configuration object to the    #
+  # route config, or setting "cors:true" in the route config to use the      #
+  # default settings below.                                                  #
+  #                                                                          #
+  ############################################################################
+
+  # allRoutes: false
+
+  ############################################################################
+  #                                                                          #
+  # Which domains which are allowed CORS access? This can be a               #
+  # comma-delimited list of hosts (beginning with http:// or https://) or    #
+  # "#" to allow all domains CORS access.                                    #
+  #                                                                          #
+  ############################################################################
+
+  # origin: '#'
+
+  ############################################################################
+  #                                                                          #
+  # Allow cookies to be shared for CORS requests?                            #
+  #                                                                          #
+  ############################################################################
+
+  # credentials: true
+
+  ############################################################################
+  #                                                                          #
+  # Which methods should be allowed for CORS requests? This is only used in  #
+  # response to preflight requests (see article linked above for more info)  #
+  #                                                                          #
+  ############################################################################
+
+  # methods: 'GET, POST, PUT, DELETE, OPTIONS, HEAD'
+
+  ############################################################################
+  #                                                                          #
+  # Which headers should be allowed for CORS requests? This is only used in  #
+  # response to preflight requests.                                          #
+  #                                                                          #
+  ############################################################################
+
+  # headers: 'content-type'
+
+}

--- a/templates/config/csrf.coffee
+++ b/templates/config/csrf.coffee
@@ -1,0 +1,63 @@
+###
+# Cross-Site Request Forgery Protection Settings
+# (sails.config.csrf)
+#
+# CSRF tokens are like a tracking chip.  While a session tells the server that a user
+# "is who they say they are", a csrf token tells the server "you are where you say you are".
+#
+# When enabled, all non-GET requests to the Sails server must be accompanied by
+# a special token, identified as the '_csrf' parameter.
+#
+# This option protects your Sails app against cross-site request forgery (or CSRF) attacks.
+# A would-be attacker needs not only a user's session cookie, but also this timestamped,
+# secret CSRF token, which is refreshed/granted when the user visits a URL on your app's domain.
+#
+# This allows us to have certainty that our users' requests haven't been hijacked,
+# and that the requests they're making are intentional and legitimate.
+#
+# This token has a short-lived expiration timeline, and must be acquired by either:
+#
+# (a)		For traditional view-driven web apps:
+#			Fetching it from one of your views, where it may be accessed as
+#			a local variable, e.g.:
+#			<form>
+#				<input type="hidden" name="_csrf" value="<%= _csrf %>" />
+#			</form>
+#
+# or (b)	For AJAX/Socket-heavy and/or single-page apps:
+#			Sending a GET request to the `/csrfToken` route, where it will be returned
+#			as JSON, e.g.:
+#			{ _csrf: 'ajg4JD(JGdajhLJALHDa' }
+#
+#
+# Enabling this option requires managing the token in your front-end app.
+# For traditional web apps, it's as easy as passing the data from a view into a form action.
+# In AJAX/Socket-heavy apps, just send a GET request to the /csrfToken route to get a valid token.
+#
+# For more information on CSRF, check out:
+# http://en.wikipedia.org/wiki/Cross-site_request_forgery
+#
+# For more information on this configuration file, including info on CSRF + CORS, see:
+# http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.csrf.html
+#
+###
+
+#############################################################################
+#                                                                           #
+# Enabled CSRF protection for your site?                                    #
+#                                                                           #
+#############################################################################
+
+# module.exports.csrf = false
+
+#############################################################################
+#                                                                           #
+# You may also specify more fine-grained settings for CSRF, including the   #
+# domains which are allowed to request the CSRF token via AJAX. These       #
+# settings override the general CORS settings in your config/cors.js file.  #
+#                                                                           #
+#############################################################################
+
+# module.exports.csrf =
+#   grantTokenViaAjax: true
+#   origin: ''

--- a/templates/config/env/development.coffee
+++ b/templates/config/env/development.coffee
@@ -1,0 +1,23 @@
+###
+# Development environment settings
+#
+# This file can include shared settings for a development team,
+# such as API keys or remote database passwords.  If you're using
+# a version control solution for your Sails app, this file will
+# be committed to your repository unless you add it to your .gitignore
+# file.  If your repository will be publicly viewable, don't add
+# any private information to this file!
+#
+###
+
+module.exports = {
+
+  ###########################################################################
+  # Set the default database connection for models in the development       #
+  # environment (see config/connections.js and config/models.js )           #
+  ###########################################################################
+
+  # models:
+  #   connection: 'someMongodbServer'
+
+}

--- a/templates/config/env/production.coffee
+++ b/templates/config/env/production.coffee
@@ -1,0 +1,36 @@
+###
+# Production environment settings
+#
+# This file can include shared settings for a production team,
+# such as API keys or remote database passwords.  If you're using
+# a version control solution for your Sails app, this file will
+# be committed to your repository unless you add it to your .gitignore
+# file.  If your repository will be publicly viewable, don't add
+# any private information to this file!
+#
+###
+
+module.exports = {
+
+  ###########################################################################
+  # Set the default database connection for models in the production        #
+  # environment (see config/connections.js and config/models.js )           #
+  ###########################################################################
+
+  # models:
+  #   connection: 'someMysqlServer'
+
+  ###########################################################################
+  # Set the port in the production environment to 80                        #
+  ###########################################################################
+
+  # port: 80
+
+  ###########################################################################
+  # Set the log level in production environment to "silent"                 #
+  ###########################################################################
+
+  # log:
+  #   level: "silent"
+
+}

--- a/templates/config/globals.coffee
+++ b/templates/config/globals.coffee
@@ -1,0 +1,65 @@
+###
+# Global Variable Configuration
+# (sails.config.globals)
+#
+# Configure which global variables which will be exposed
+# automatically by Sails.
+#
+# For more information on configuration, check out:
+# http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.globals.html
+###
+
+module.exports.globals = {
+
+  #############################################################################
+  #                                                                           #
+  # Expose the lodash installed in Sails core as a global variable. If this   #
+  # is disabled, like any other node module you can always run npm install    #
+  # lodash --save, then var _ = require('lodash') at the top of any file.     #
+  #                                                                           #
+  #############################################################################
+
+  # _: true
+
+  #############################################################################
+  #                                                                           #
+  # Expose the async installed in Sails core as a global variable. If this is #
+  # disabled, like any other node module you can always run npm install async #
+  # --save, then var async = require('async') at the top of any file.         #
+  #                                                                           #
+  #############################################################################
+
+  # async: true
+
+  #############################################################################
+  #                                                                           #
+  # Expose the sails instance representing your app. If this is disabled, you #
+  # can still get access via req._sails.                                      #
+  #                                                                           #
+  #############################################################################
+
+  # sails: true
+
+  #############################################################################
+  #                                                                           #
+  # Expose each of your app's services as global variables (using their       #
+  # "globalId"). E.g. a service defined in api/models/NaturalLanguage.js      #
+  # would have a globalId of NaturalLanguage by default. If this is disabled, #
+  # you can still access your services via sails.services.#                   #
+  #                                                                           #
+  #############################################################################
+
+  # services: true
+
+  #############################################################################
+  #                                                                           #
+  # Expose each of your app's models as global variables (using their         #
+  # "globalId"). E.g. a model defined in api/models/User.js would have a      #
+  # globalId of User by default. If this is disabled, you can still access    #
+  # your models via sails.models.#.                                           #
+  #                                                                           #
+  #############################################################################
+
+  # models: true
+
+}

--- a/templates/config/http.coffee
+++ b/templates/config/http.coffee
@@ -1,0 +1,84 @@
+###
+# HTTP Server Settings
+# (sails.config.http)
+#
+# Configuration for the underlying HTTP server in Sails.
+# Only applies to HTTP requests (not WebSockets)
+#
+# For more information on configuration, check out:
+# http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.http.html
+###
+
+module.exports.http = {
+
+  #############################################################################
+  #                                                                           #
+  # Express middleware to use for every Sails request. To add custom          #
+  # middleware to the mix, add a function to the middleware config object and #
+  # add its key to the "order" array. The $custom key is reserved for         #
+  # backwards-compatibility with Sails v0.9.x apps that use the               #
+  # `customMiddleware` config option.                                         #
+  #                                                                           #
+  #############################################################################
+
+  # middleware:
+
+  ############################################################################
+  #                                                                          #
+  # The order in which middleware should be run for HTTP request. (the Sails #
+  # router is invoked by the "router" middleware below.)                     #
+  #                                                                          #
+  ############################################################################
+
+    # order: [
+    #   'startRequestTimer'
+    #   'cookieParser'
+    #   'session'
+    #   'myRequestLogger'
+    #   'bodyParser'
+    #   'handleBodyParserError'
+    #   'compress'
+    #   'methodOverride'
+    #   'poweredBy'
+    #   '$custom'
+    #   'router'
+    #   'www'
+    #   'favicon'
+    #   '404'
+    #   '500'
+    # ]
+
+  #############################################################################
+  #                                                                           #
+  # Example custom middleware; logs each request to the console.              #
+  #                                                                           #
+  #############################################################################
+
+    # myRequestLogger: (req, res, next) ->
+    #   console.log "Requested :: ", req.method, req.url
+    #   next()
+
+  ############################################################################
+  #                                                                          #
+  # The body parser that will handle incoming multipart HTTP requests. By    #
+  # default as of v0.10, Sails uses                                          #
+  # [skipper](http://github.com/balderdashy/skipper). See                    #
+  # http://www.senchalabs.org/connect/multipart.html for other options.      #
+  #                                                                          #
+  ############################################################################
+
+    # bodyParser: require 'skipper'
+
+  ############################################################################
+  #                                                                          #
+  # The number of seconds to cache flat files on disk being served by        #
+  # Express static middleware (by default, these files are in `.tmp/public`) #
+  #                                                                          #
+  # The HTTP static cache is only active in a 'production' environment,      #
+  # since that's the only time Express will cache flat-files.                #
+  #                                                                          #
+  ############################################################################
+
+  # cache: 31557600000
+
+}

--- a/templates/config/i18n.coffee
+++ b/templates/config/i18n.coffee
@@ -1,0 +1,62 @@
+###
+# Internationalization / Localization Settings
+# (sails.config.i18n)
+#
+# If your app will touch people from all over the world, i18n (or internationalization)
+# may be an important part of your international strategy.
+#
+#
+# For more information on i18n in Sails, check out:
+# http://sailsjs.org/#!/documentation/concepts/Internationalization
+#
+# For a complete list of i18n options, see:
+# https://github.com/mashpie/i18n-node#list-of-configuration-options
+#
+#
+###
+
+module.exports.i18n = {
+
+  ############################################################################
+  #                                                                          #
+  # Which locales are supported?                                             #
+  #                                                                          #
+  ############################################################################
+
+  # locales: [
+  #   'en'
+  #   'es'
+  #   'fr'
+  #   'de'
+  # ]
+
+  #############################################################################
+  #                                                                           #
+  # What is the default locale for the site? Note that this setting will be   #
+  # overridden for any request that sends an "Accept-Language" header (i.e.   #
+  # most browsers), but it's still useful if you need to localize the         #
+  # response for requests made by non-browser clients (e.g. cURL).            #
+  #                                                                           #
+  #############################################################################
+
+  # defaultLocale: 'en'
+
+  #############################################################################
+  #                                                                           #
+  # Automatically add new keys to locale (translation) files when they are    #
+  # encountered during a request?                                             #
+  #                                                                           #
+  #############################################################################
+
+  # updateFiles: false
+
+  #############################################################################
+  #                                                                           #
+  # Path (relative to app root) of directory to store locale (translation)    #
+  # files in.                                                                 #
+  #                                                                           #
+  #############################################################################
+
+  # localesDirectory: '/config/locales'
+
+}

--- a/templates/config/i18n.js
+++ b/templates/config/i18n.js
@@ -6,7 +6,7 @@
  * may be an important part of your international strategy.
  *
  *
- * For more informationom i18n in Sails, check out:
+ * For more information on i18n in Sails, check out:
  * http://sailsjs.org/#!/documentation/concepts/Internationalization
  *
  * For a complete list of i18n options, see:

--- a/templates/config/local.coffee
+++ b/templates/config/local.coffee
@@ -1,0 +1,84 @@
+###
+# Local environment settings
+#
+# Use this file to specify configuration settings for use while developing
+# the app on your personal system: for example, this would be a good place
+# to store database or email passwords that apply only to you, and shouldn't
+# be shared with others in your organization.
+#
+# These settings take precedence over all other config files, including those
+# in the env/ subfolder.
+#
+# PLEASE NOTE:
+#		local.js is included in your .gitignore, so if you're using git
+#		as a version control solution for your Sails app, keep in mind that
+#		this file won't be committed to your repository!
+#
+#		Good news is, that means you can specify configuration for your local
+#		machine in this file without inadvertently committing personal information
+#		(like database passwords) to the repo.  Plus, this prevents other members
+#		of your team from commiting their local configuration changes on top of yours.
+#
+#    In a production environment, you probably want to leave this file out
+#    entirely and leave all your settings in env/production.js
+#
+#
+# For more information, check out:
+# http://sailsjs.org/#!/documentation/anatomy/myApp/config/local.js.html
+###
+
+module.exports = {
+
+  ###########################################################################
+  # Your SSL certificate and key, if you want to be able to serve HTTP      #
+  # responses over https:// and/or use websockets over the wss:// protocol  #
+  # (recommended for HTTP, strongly encouraged for WebSockets)              #
+  #                                                                         #
+  # In this example, we'll assume you created a folder in your project,     #
+  # `config/ssl` and dumped your certificate/key files there:               #
+  ###########################################################################
+
+  # ssl:
+  #   ca: require('fs').readFileSync(__dirname + './ssl/my_apps_ssl_gd_bundle.crt')
+  #   key: require('fs').readFileSync(__dirname + './ssl/my_apps_ssl.key')
+  #   cert: require('fs').readFileSync(__dirname + './ssl/my_apps_ssl.crt')
+
+  ###########################################################################
+  # The `port` setting determines which TCP port your app will be           #
+  # deployed on.                                                            #
+  #                                                                         #
+  # Ports are a transport-layer concept designed to allow many different    #
+  # networking applications run at the same time on a single computer.      #
+  # More about ports:                                                       #
+  # http://en.wikipedia.org/wiki/Port_(computer_networking)                 #
+  #                                                                         #
+  # By default, if it's set, Sails uses the `PORT` environment variable.    #
+  # Otherwise it falls back to port 1337.                                   #
+  #                                                                         #
+  # In env/production.js, you'll probably want to change this setting       #
+  # to 80 (http://) or 443 (https://) if you have an SSL certificate        #
+  ###########################################################################
+
+  # port: process.env.PORT || 1337
+
+  ###########################################################################
+  # The runtime "environment" of your Sails app is either typically         #
+  # 'development' or 'production'.                                          #
+  #                                                                         #
+  # In development, your Sails app will go out of its way to help you       #
+  # (for instance you will receive more descriptive error and               #
+  # debugging output)                                                       #
+  #                                                                         #
+  # In production, Sails configures itself (and its dependencies) to        #
+  # optimize performance. You should always put your app in production mode #
+  # before you deploy it to a server.  This helps ensure that your Sails    #
+  # app remains stable, performant, and scalable.                           #
+  #                                                                         #
+  # By default, Sails sets its environment using the `NODE_ENV` environment #
+  # variable.  If NODE_ENV is not set, Sails will run in the                #
+  # 'development' environment.                                              #
+  ###########################################################################
+
+  # environment: process.env.NODE_ENV || 'development'
+
+}

--- a/templates/config/log.coffee
+++ b/templates/config/log.coffee
@@ -1,0 +1,29 @@
+###
+# Built-in Log Configuration
+# (sails.config.log)
+#
+# Configure the log level for your app, as well as the transport
+# (Underneath the covers, Sails uses Winston for logging, which
+# allows for some pretty neat custom transports/adapters for log messages)
+#
+# For more information on the Sails logger, check out:
+# http://sailsjs.org/#!/documentation/concepts/Logging
+###
+
+module.exports.log = {
+
+  ############################################################################
+  #                                                                          #
+  # Valid `level` configs: i.e. the minimum log level to capture with        #
+  # sails.log.#()                                                            #
+  #                                                                          #
+  # The order of precedence for log levels from lowest to highest is:        #
+  # silly, verbose, info, debug, warn, error                                 #
+  #                                                                          #
+  # You may also set the level to "silent" to suppress all logs.             #
+  #                                                                          #
+  ############################################################################
+
+  # level: 'info'
+
+}

--- a/templates/config/models.coffee
+++ b/templates/config/models.coffee
@@ -1,0 +1,34 @@
+###
+# Default model configuration
+# (sails.config.models)
+#
+# Unless you override them, the following properties will be included
+# in each of your models.
+#
+# For more info on Sails models, see:
+# http://sailsjs.org/#!/documentation/concepts/ORM
+###
+
+module.exports.models = {
+
+  ############################################################################
+  #                                                                          #
+  # Your app's default connection. i.e. the name of one of your app's        #
+  # connections (see `config/connections.js`)                                #
+  #                                                                          #
+  ############################################################################
+
+  # connection: 'localDiskDb'
+
+  ############################################################################
+  #                                                                          #
+  # How and whether Sails will attempt to automatically rebuild the          #
+  # tables/collections/etc. in your schema.                                  #
+  #                                                                          #
+  # See http://sailsjs.org/#!/documentation/concepts/ORM/model-settings.html #
+  #                                                                          #
+  ############################################################################
+
+  # migrate: 'alter'
+
+}

--- a/templates/config/policies.coffee
+++ b/templates/config/policies.coffee
@@ -1,0 +1,55 @@
+###
+# Policy Mappings
+# (sails.config.policies)
+#
+# Policies are simple functions which run **before** your controllers.
+# You can apply one or more policies to a given controller, or protect
+# its actions individually.
+#
+# Any policy file (e.g. `api/policies/authenticated.js`) can be accessed
+# below by its filename, minus the extension, (e.g. "authenticated")
+#
+# For more information on how policies work, see:
+# http://sailsjs.org/#!/documentation/concepts/Policies
+#
+# For more information on configuring policies, check out:
+# http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.policies.html
+###
+
+module.exports.policies = {
+
+  ############################################################################
+  #                                                                          #
+  # Default policy for all controllers and actions (`true` allows public     #
+  # access)                                                                  #
+  #                                                                          #
+  ############################################################################
+
+  # '#': true
+
+  ############################################################################
+  #                                                                          #
+  # Here's an example of mapping some policies to run before a controller    #
+  # and its actions                                                          #
+  #                                                                          #
+  ############################################################################
+
+  # RabbitController:
+
+    # Apply the `false` policy as the default for all of RabbitController's actions
+    # (`false` prevents all access, which ensures that nothing bad happens to our rabbits)
+    # '#': false
+
+    # For the action `nurture`, apply the 'isRabbitMother' policy
+    # (this overrides `false` above)
+    # nurture: 'isRabbitMother'
+
+    # Apply the `isNiceToAnimals` AND `hasRabbitFood` policies
+    # before letting any users feed our rabbits
+    # feed: [
+    #   'isNiceToAnimals'
+    #   'hasRabbitFood'
+    # ]
+  # }
+
+}

--- a/templates/config/routes.coffee
+++ b/templates/config/routes.coffee
@@ -1,0 +1,48 @@
+###
+# Route Mappings
+# (sails.config.routes)
+#
+# Your routes map URLs to views and controllers.
+#
+# If Sails receives a URL that doesn't match any of the routes below,
+# it will check for matching files (images, scripts, stylesheets, etc.)
+# in your assets directory.  e.g. `http://localhost:1337/images/foo.jpg`
+# might match an image file: `/assets/images/foo.jpg`
+#
+# Finally, if those don't match either, the default 404 handler is triggered.
+# See `api/responses/notFound.js` to adjust your app's 404 logic.
+#
+# Note: Sails doesn't ACTUALLY serve stuff from `assets`-- the default Gruntfile in Sails copies
+# flat files from `assets` to `.tmp/public`.  This allows you to do things like compile LESS or
+# CoffeeScript for the front-end.
+#
+# For more information on configuring custom routes, check out:
+# http://sailsjs.org/#!/documentation/concepts/Routes/RouteTargetSyntax.html
+###
+
+module.exports.routes = {
+
+  ############################################################################
+  #                                                                          #
+  # Make the view located at `views/homepage.ejs` (or `views/homepage.jade`, #
+  # etc. depending on your default view engine) your home page.              #
+  #                                                                          #
+  # (Alternatively, remove this and add an `index.html` file in your         #
+  # `assets` directory)                                                      #
+  #                                                                          #
+  ############################################################################
+
+  '/':
+    view: 'homepage'
+
+  ############################################################################
+  #                                                                          #
+  # Custom routes here...                                                    #
+  #                                                                          #
+  # If a request to a URL doesn't match any of the custom routes above, it   #
+  # is matched against Sails route blueprints. See `config/blueprints.js`    #
+  # for configuration options and examples.                                  #
+  #                                                                          #
+  ############################################################################
+
+}

--- a/templates/config/session.coffee
+++ b/templates/config/session.coffee
@@ -1,0 +1,88 @@
+###
+# Session Configuration
+# (sails.config.session)
+#
+# Sails session integration leans heavily on the great work already done by
+# Express, but also unifies Socket.io with the Connect session store. It uses
+# Connect's cookie parser to normalize configuration differences between Express
+# and Socket.io and hooks into Sails' middleware interpreter to allow you to access
+# and auto-save to `req.session` with Socket.io the same way you would with Express.
+#
+# For more information on configuring the session, check out:
+# http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.session.html
+###
+
+module.exports.session = {
+
+  ############################################################################
+  #                                                                          #
+  # Session secret is automatically generated when your new app is created   #
+  # Replace at your own risk in production-- you will invalidate the cookies #
+  # of your users, forcing them to log in again.                             #
+  #                                                                          #
+  ############################################################################
+
+  secret: '<%= secret %>'
+
+  ############################################################################
+  #                                                                          #
+  # Set the session cookie expire time The maxAge is set by milliseconds,    #
+  # the example below is for 24 hours                                        #
+  #                                                                          #
+  ############################################################################
+
+  # cookie:
+  #   maxAge: 24 # 60 # 60 # 1000
+
+  ############################################################################
+  #                                                                          #
+  # In production, uncomment the following lines to set up a shared redis    #
+  # session store that can be shared across multiple Sails.js servers        #
+  ############################################################################
+
+  # adapter: 'redis'
+
+  ############################################################################
+  #                                                                          #
+  # The following values are optional, if no options are set a redis         #
+  # instance running on localhost is expected. Read more about options at:   #
+  # https://github.com/visionmedia/connect-redis                             #
+  #                                                                          #
+  ############################################################################
+
+  # host: 'localhost'
+  # port: 6379
+  # ttl: <redis session TTL in seconds>
+  # db: 0
+  # pass: <redis auth password>
+  # prefix: 'sess:'
+
+  ############################################################################
+  #                                                                          #
+  # Uncomment the following lines to use your Mongo adapter as a session     #
+  # store                                                                    #
+  #                                                                          #
+  ############################################################################
+
+  # adapter: 'mongo'
+  # host: 'localhost'
+  # port: 27017
+  # db: 'sails'
+  # collection: 'sessions'
+
+  ############################################################################
+  #                                                                          #
+  # Optional Values:                                                         #
+  #                                                                          #
+  # # Note: url will override other connection settings url:                 #
+  # 'mongodb://user:pass@host:port/database/collection',                     #
+  #                                                                          #
+  ############################################################################
+
+  # username: ''
+  # password: ''
+  # auto_reconnect: false
+  # ssl: false
+  # stringify: true
+
+}

--- a/templates/config/session.js
+++ b/templates/config/session.js
@@ -49,7 +49,6 @@ module.exports.session = {
   * instance running on localhost is expected. Read more about options at:   *
   * https://github.com/visionmedia/connect-redis                             *
   *                                                                          *
-  *                                                                          *
   ***************************************************************************/
 
   // host: 'localhost',

--- a/templates/config/sockets.coffee
+++ b/templates/config/sockets.coffee
@@ -1,0 +1,140 @@
+###*
+# WebSocket Server Settings
+# (sails.config.sockets)
+#
+# These settings provide transparent access to the options for Sails'
+# encapsulated WebSocket server, as well as some additional Sails-specific
+# configuration layered on top.
+#
+# For more information on sockets configuration, including advanced config options, see:
+# http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.sockets.html
+###
+
+module.exports.sockets = {
+
+  ############################################################################
+  #                                                                          #
+  # Node.js (and consequently Sails.js) apps scale horizontally. It's a      #
+  # powerful, efficient approach, but it involves a tiny bit of planning. At #
+  # scale, you'll want to be able to copy your app onto multiple Sails.js    #
+  # servers and throw them behind a load balancer.                           #
+  #                                                                          #
+  # One of the big challenges of scaling an application is that these sorts  #
+  # of clustered deployments cannot share memory, since they are on          #
+  # physically different machines. On top of that, there is no guarantee     #
+  # that a user will "stick" with the same server between requests (whether  #
+  # HTTP or sockets), since the load balancer will route each request to the #
+  # Sails server with the most available resources. However that means that  #
+  # all room/pubsub/socket processing and shared memory has to be offloaded  #
+  # to a shared, remote messaging queue (usually Redis)                      #
+  #                                                                          #
+  # Luckily, Socket.io (and consequently Sails.js) apps support Redis for    #
+  # sockets by default. To enable a remote redis pubsub server, uncomment    #
+  # the config below.                                                        #
+  #                                                                          #
+  # Worth mentioning is that, if `adapter` config is `redis`, but host/port  #
+  # is left unset, Sails will try to connect to redis running on localhost   #
+  # via port 6379                                                            #
+  #                                                                          #
+  ############################################################################
+
+  # adapter: 'memory'
+
+  #
+  # -OR-
+  #
+
+  # adapter: 'redis'
+  # host: '127.0.0.1'
+  # port: 6379
+  # db: 'sails'
+  # pass: '<redis auth password>'
+
+  ############################################################################
+  #                                                                          #
+  # Whether to expose a 'get /__getcookie' route with CORS support that sets #
+  # a cookie (this is used by the sails.io.js socket client to get access to #
+  # a 3rd party cookie and to enable sessions).                              #
+  #                                                                          #
+  # Warning: Currently in this scenario, CORS settings apply to interpreted  #
+  # requests sent via a socket.io connection that used this cookie to        #
+  # connect, even for non-browser clients! (e.g. iOS apps, toasters, node.js #
+  # unit tests)                                                              #
+  #                                                                          #
+  ############################################################################
+
+  # grant3rdPartyCookie: true
+
+  ############################################################################
+  #                                                                          #
+  # `beforeConnect`                                                          #
+  #                                                                          #
+  # This custom beforeConnect function will be run each time BEFORE a new    #
+  # socket is allowed to connect, when the initial socket.io handshake is    #
+  # performed with the server.                                               #
+  #                                                                          #
+  # By default, when a socket tries to connect, Sails allows it, every time. #
+  # (much in the same way any HTTP request is allowed to reach your routes.  #
+  # If no valid cookie was sent, a temporary session will be created for the #
+  # connecting socket.                                                       #
+  #                                                                          #
+  # If the cookie sent as part of the connection request doesn't match any   #
+  # known user session, a new user session is created for it.                #
+  #                                                                          #
+  # In most cases, the user would already have a cookie since they loaded    #
+  # the socket.io client and the initial HTML page you're building.          #
+  #                                                                          #
+  # However, in the case of cross-domain requests, it is possible to receive #
+  # a connection upgrade request WITHOUT A COOKIE (for certain transports)   #
+  # In this case, there is no way to keep track of the requesting user       #
+  # between requests, since there is no identifying information to link      #
+  # him/her with a session. The sails.io.js client solves this by connecting #
+  # to a CORS/jsonp endpoint first to get a 3rd party cookie(fortunately this#
+  # works, even in Safari), then opening the connection.                     #
+  #                                                                          #
+  # You can also pass along a ?cookie query parameter to the upgrade url,    #
+  # which Sails will use in the absence of a proper cookie e.g. (when        #
+  # connecting from the client):                                             #
+  # io.sails.connect('http://localhost:1337?cookie=smokeybear')              #
+  #                                                                          #
+  # Finally note that the user's cookie is NOT (and will never be) accessible#
+  # from client-side javascript. Using HTTP-only cookies is crucial for your #
+  # app's security.                                                          #
+  #                                                                          #
+  ############################################################################
+
+  # beforeConnect: (handshake, cb) ->
+  #   # `true` allows the connection
+  #   cb null, true
+  #
+  #   # (`false` would reject the connection)
+
+  ############################################################################
+  #                                                                          #
+  # `afterDisconnect`                                                        #
+  #                                                                          #
+  # This custom afterDisconnect function will be run each time a socket      #
+  # disconnects                                                              #
+  #                                                                          #
+  ############################################################################
+
+  # afterDisconnect: (session, socket, cb) ->
+  #   # By default: do nothing.
+  #   cb()
+
+  ############################################################################
+  #                                                                          #
+  # `transports`                                                             #
+  #                                                                          #
+  # A array of allowed transport methods which the clients will try to use.  #
+  # On server environments that don't support sticky sessions, the "polling" #
+  # transport should be disabled.                                            #
+  #                                                                          #
+  ############################################################################
+
+  # transports: [
+  #   "polling"
+  #   "websocket"
+  # ]
+
+}

--- a/templates/config/sockets.js
+++ b/templates/config/sockets.js
@@ -86,7 +86,7 @@ module.exports.sockets = {
   * known user session, a new user session is created for it.                *
   *                                                                          *
   * In most cases, the user would already have a cookie since they loaded    *
-  * the socket.io client and the initial HTML page you're building.         *
+  * the socket.io client and the initial HTML page you're building.          *
   *                                                                          *
   * However, in the case of cross-domain requests, it is possible to receive *
   * a connection upgrade request WITHOUT A COOKIE (for certain transports)   *

--- a/templates/config/views.coffee
+++ b/templates/config/views.coffee
@@ -1,0 +1,98 @@
+###
+# View Engine Configuration
+# (sails.config.views)
+#
+# Server-sent views are a classic and effective way to get your app up
+# and running. Views are normally served from controllers.  Below, you can
+# configure your templating language/framework of choice and configure
+# Sails' layout support.
+#
+# For more information on views and layouts, check out:
+# http://sailsjs.org/#!/documentation/concepts/Views
+###
+
+module.exports.views = {
+
+  #############################################################################
+  #                                                                           #
+  # View engine (aka template language) to use for your app's #server-side#   #
+  # views                                                                     #
+  #                                                                           #
+  # Sails+Express supports all view engines which implement TJ Holowaychuk's  #
+  # `consolidate.js`, including, but not limited to:                          #
+  #                                                                           #
+  # ejs, jade, handlebars, mustache underscore, hogan, haml, haml-coffee,     #
+  # dust atpl, eco, ect, jazz, jqtpl, JUST, liquor, QEJS, swig, templayed,    #
+  # toffee, walrus, & whiskers                                                #
+  #                                                                           #
+  # For more options, check out the docs:                                     #
+  # https://github.com/balderdashy/sails-wiki/blob/0.9/config.views.md#engine #
+  #                                                                           #
+  #############################################################################
+
+  engine: '<%= viewEngine %>'
+
+<% if (typeof layout !== 'undefined') { %>
+  #############################################################################
+  #                                                                           #
+  # Layouts are simply top-level HTML templates you can use as wrappers for   #
+  # your server-side views. If you're using ejs or jade, you can take         #
+  # advantage of Sails' built-in `layout` support.                            #
+  #                                                                           #
+  # When using a layout, when one of your views is served, it is injected     #
+  # into the `body` partial defined in the layout. This lets you reuse header #
+  # and footer logic between views.                                           #
+  #                                                                           #
+  # NOTE: Layout support is only implemented for the `ejs` view engine!       #
+  #       For most other engines, it is not necessary, since they implement   #
+  #       partials/layouts themselves. In those cases, this config will be    #
+  #       silently ignored.                                                   #
+  #                                                                           #
+  # The `layout` setting may be set to one of the following:                  #
+  #                                                                           #
+  # If `false`, layouts will be disabled. Otherwise, if a string is           #
+  # specified, it will be interpreted as the relative path to your layout     #
+  # file from `views/` folder. (the file extension, ".ejs", should be         #
+  # omitted)                                                                  #
+  #                                                                           #
+  #############################################################################
+
+  #############################################################################
+  #                                                                           #
+  # Using Multiple Layouts                                                    #
+  #                                                                           #
+  # If you're using the default `ejs` or `handlebars` Sails supports the use  #
+  # of multiple `layout` files. To take advantage of this, before rendering a #
+  # view, override the `layout` local in your controller by setting           #
+  # `res.locals.layout`. (this is handy if you parts of your app's UI look    #
+  # completely different from each other)                                     #
+  #                                                                           #
+  # e.g. your default might be                                                #
+  # layout: 'layouts/public'                                                  #
+  #                                                                           #
+  # But you might override that in some of your controllers with:             #
+  # layout: 'layouts/internal'                                                #
+  #                                                                           #
+  #############################################################################
+
+    layout: '<%= layout %>'
+
+  #############################################################################
+  #                                                                           #
+  # Partials are simply top-level snippets you can leverage to reuse template #
+  # for your server-side views. If you're using handlebars, you can take      #
+  # advantage of Sails' built-in `partials` support.                          #
+  #                                                                           #
+  # If `false` or empty partials will be located in the same folder as views. #
+  # Otherwise, if a string is specified, it will be interpreted as the        #
+  # relative path to your partial files from `views/` folder.                 #
+  #                                                                           #
+  #############################################################################
+<% if (typeof partials !== 'undefined') { %>
+  partials: '<%= partials %>'
+<% } else { %>
+  partials: false
+<% } %>
+<% } %>
+
+}

--- a/test/fixtures/template-files.js
+++ b/test/fixtures/template-files.js
@@ -1,0 +1,169 @@
+var templateFiles = {
+  simpleJs: {
+    given: {
+      templateFiles: {
+        views: '.',
+        folder: [
+          'api/controllers'
+        ],
+        copy: [
+          'api/controllers/.gitkeep',
+          'config/locales/de.json',
+          'config/locales/_README.md',
+          'config/connections.js'
+        ],
+        template: [
+          'config/session.js'
+        ]
+      },
+      coffeeTemplate: false
+    },
+    expected: {
+      '.': ['views'],
+      './api/controllers'         : {folder: {}},
+      './api/controllers/.gitkeep': {copy: '.gitkeep'},
+      './config/locales/de.json'  : {copy: 'config/locales/de.json'},
+      './config/locales/_README.md': {copy: 'config/locales/_README.md'},
+      './config/connections.js'   : {copy: 'config/connections.js'},
+      './config/session.js'       : {template: 'config/session.js'}
+    }
+  },
+
+  simpleCoffee: {
+    given: {
+      templateFiles: {
+        views: '.',
+        folder: [
+          'api/controllers'
+        ],
+        copy: [
+          'api/controllers/.gitkeep',
+          'config/locales/de.json',
+          'config/locales/_README.md',
+          'config/connections.js'
+        ],
+        template: [
+          'config/session.js'
+        ]
+      },
+      coffeeTemplate: true
+    },
+    expected: {
+      '.': ['views'],
+      './api/controllers': {folder: {}},
+      './api/controllers/.gitkeep': {copy: '.gitkeep'},
+      './config/locales/de.json'  : {copy: 'config/locales/de.json'},
+      './config/locales/_README.md': {copy: 'config/locales/_README.md'},
+      './config/connections.coffee'   : {copy: 'config/connections.coffee'},
+      './config/session.coffee'       : {template: 'config/session.coffee'}
+    }
+  },
+  originalJs: {
+    expected: {
+      '.': ['views'],
+      './api/controllers': {folder: {}},
+      './api/models': {folder: {}},
+      './api/policies': {folder: {}},
+      './api/services': {folder: {}},
+      './api/responses': {folder: {}},
+
+      './api/controllers/.gitkeep': {copy: '.gitkeep'},
+      './api/models/.gitkeep': {copy: '.gitkeep'},
+      './api/services/.gitkeep': {copy: '.gitkeep'},
+      './config/connections.js': {copy: 'config/connections.js'},
+      './config/models.js': {copy: 'config/models.js'},
+      './config/blueprints.js': {copy: 'config/blueprints.js'},
+      './config/bootstrap.js': {copy: 'config/bootstrap.js'},
+      './config/cors.js': {copy: 'config/cors.js'},
+      './config/csrf.js': {copy: 'config/csrf.js'},
+      './config/http.js': {copy: 'config/http.js'},
+      './config/globals.js': {copy: 'config/globals.js'},
+      './config/i18n.js': {copy: 'config/i18n.js'},
+      './config/local.js': {copy: 'config/local.js'},
+      './config/log.js': {copy: 'config/log.js'},
+      './config/policies.js': {copy: 'config/policies.js'},
+      './config/routes.js': {copy: 'config/routes.js'},
+      './config/sockets.js': {copy: 'config/sockets.js'},
+
+      './config/session.js': {template: 'config/session.js'},
+      './config/views.js': {template: 'config/views.js'},
+
+      './config/locales/de.json': {copy: 'config/locales/de.json'},
+      './config/locales/en.json': {copy: 'config/locales/en.json'},
+      './config/locales/es.json': {copy: 'config/locales/es.json'},
+      './config/locales/fr.json': {copy: 'config/locales/fr.json'},
+      './config/locales/_README.md': {copy: 'config/locales/_README.md'},
+
+      './config/env/production.js': {copy: 'config/env/production.js'},
+      './config/env/development.js': {copy: 'config/env/development.js'},
+
+      './api/policies/sessionAuth.js': {copy: 'api/policies/sessionAuth.js'},
+
+      './api/responses/badRequest.js': {copy: 'api/responses/badRequest.js'},
+      './api/responses/forbidden.js': {copy: 'api/responses/forbidden.js'},
+      './api/responses/notFound.js': {copy: 'api/responses/notFound.js'},
+      './api/responses/serverError.js': {copy: 'api/responses/serverError.js'},
+      './api/responses/ok.js': {copy: 'api/responses/ok.js'},
+
+      // Excluding `res.negotiate()` from the generated files for now,
+      // since it's best if its definition is consistent between projects.
+      // It can still be overridden by creating api/responses/negotiate.js.
+      // './api/responses/negotiate.js': { copy: 'api/responses/negotiate.js' },
+    }
+  },
+  originalCoffee: {
+    expected: {
+      '.': ['views'],
+      './api/controllers': {folder: {}},
+      './api/models': {folder: {}},
+      './api/policies': {folder: {}},
+      './api/services': {folder: {}},
+      './api/responses': {folder: {}},
+
+      './api/controllers/.gitkeep': {copy: '.gitkeep'},
+      './api/models/.gitkeep': {copy: '.gitkeep'},
+      './api/services/.gitkeep': {copy: '.gitkeep'},
+      './config/connections.coffee': {copy: 'config/connections.coffee'},
+      './config/models.coffee': {copy: 'config/models.coffee'},
+      './config/blueprints.coffee': {copy: 'config/blueprints.coffee'},
+      './config/bootstrap.coffee': {copy: 'config/bootstrap.coffee'},
+      './config/cors.coffee': {copy: 'config/cors.coffee'},
+      './config/csrf.coffee': {copy: 'config/csrf.coffee'},
+      './config/http.coffee': {copy: 'config/http.coffee'},
+      './config/globals.coffee': {copy: 'config/globals.coffee'},
+      './config/i18n.coffee': {copy: 'config/i18n.coffee'},
+      './config/local.coffee': {copy: 'config/local.coffee'},
+      './config/log.coffee': {copy: 'config/log.coffee'},
+      './config/policies.coffee': {copy: 'config/policies.coffee'},
+      './config/routes.coffee': {copy: 'config/routes.coffee'},
+      './config/sockets.coffee': {copy: 'config/sockets.coffee'},
+
+      './config/session.coffee': {template: 'config/session.coffee'},
+      './config/views.coffee': {template: 'config/views.coffee'},
+
+      './config/locales/de.json': {copy: 'config/locales/de.json'},
+      './config/locales/en.json': {copy: 'config/locales/en.json'},
+      './config/locales/es.json': {copy: 'config/locales/es.json'},
+      './config/locales/fr.json': {copy: 'config/locales/fr.json'},
+      './config/locales/_README.md': {copy: 'config/locales/_README.md'},
+
+      './config/env/production.coffee': {copy: 'config/env/production.coffee'},
+      './config/env/development.coffee': {copy: 'config/env/development.coffee'},
+
+      './api/policies/sessionAuth.coffee': {copy: 'api/policies/sessionAuth.coffee'},
+
+      './api/responses/badRequest.coffee': {copy: 'api/responses/badRequest.coffee'},
+      './api/responses/forbidden.coffee': {copy: 'api/responses/forbidden.coffee'},
+      './api/responses/notFound.coffee': {copy: 'api/responses/notFound.coffee'},
+      './api/responses/serverError.coffee': {copy: 'api/responses/serverError.coffee'},
+      './api/responses/ok.coffee': {copy: 'api/responses/ok.coffee'},
+
+      // Excluding `res.negotiate()` from the generated files for now,
+      // since it's best if its definition is consistent between projects.
+      // It can still be overridden by creating api/responses/negotiate.coffee.
+      // './api/responses/negotiate.coffee': { copy: 'api/responses/negotiate.coffee' },
+    }
+  }
+};
+
+module.exports = templateFiles;

--- a/test/targets.test.js
+++ b/test/targets.test.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+var targets = require('../lib/targets');
+var templateFiles = require('./fixtures/template-files');
+
+describe('Targets', function() {
+
+  it('should generate targets (js) from a simple templates file', function() {
+    var given = templateFiles.simpleJs.given;
+    var actual = targets.buildTargets(given.templateFiles, given.coffeeTemplate);
+    var expected = templateFiles.simpleJs.expected;
+
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should generate targets (coffee) from a simple templates file', function() {
+    var given = templateFiles.simpleCoffee.given;
+    var actual = targets.buildTargets(given.templateFiles, given.coffeeTemplate);
+    var expected = templateFiles.simpleCoffee.expected;
+
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should generate the original targets (js)', function() {
+    var given = targets;
+    var actual = targets.buildTargets(given.templateFiles);
+    var expected = templateFiles.originalJs.expected;
+
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should generate the original targets (coffee)', function() {
+    var given = targets;
+    var actual = targets.buildTargets(given.templateFiles, true);
+    var expected = templateFiles.originalCoffee.expected;
+
+    assert.deepEqual(actual, expected);
+  });
+});


### PR DESCRIPTION
Added '--coffee' generator option for generating coffeescript files instead of javascript files.
Tests have been added to make sure the original list of files to generate are exactly the same than before.

Relative to the [issue #1923](https://github.com/balderdashy/sails/issues/1923)