### PR TITLE
Fix : prevent crashing when views are disabled

### DIFF
--- a/templates/api/responses/badRequest.js
+++ b/templates/api/responses/badRequest.js
@@ -39,7 +39,8 @@ module.exports = function badRequest(data, options) {
   }
 
   // If the user-agent wants JSON, always respond with JSON
-  if (req.wantsJSON) {
+  // If views are disabled, revert to json
+  if (req.wantsJSON || sails.config.hooks.views === false) {
     return res.jsonx(data);
   }
 

--- a/templates/api/responses/created.js
+++ b/templates/api/responses/created.js
@@ -24,7 +24,8 @@ module.exports = function sendOK (data, options) {
   res.status(201);
 
   // If appropriate, serve data as JSON(P)
-  if (req.wantsJSON) {
+  // If views are disabled, revert to json
+  if (req.wantsJSON || sails.config.hooks.views === false) {
     return res.jsonx(data);
   }
 

--- a/templates/api/responses/forbidden.js
+++ b/templates/api/responses/forbidden.js
@@ -36,7 +36,8 @@ module.exports = function forbidden (data, options) {
   }
 
   // If the user-agent wants JSON, always respond with JSON
-  if (req.wantsJSON) {
+  // If views are disabled, revert to json
+  if (req.wantsJSON || sails.config.hooks.views === false) {
     return res.jsonx(data);
   }
 

--- a/templates/api/responses/notFound.js
+++ b/templates/api/responses/notFound.js
@@ -41,7 +41,8 @@ module.exports = function notFound (data, options) {
   }
 
   // If the user-agent wants JSON, always respond with JSON
-  if (req.wantsJSON) {
+  // If views are disabled, revert to json
+  if (req.wantsJSON || sails.config.hooks.views === false) {
     return res.jsonx(data);
   }
 

--- a/templates/api/responses/ok.js
+++ b/templates/api/responses/ok.js
@@ -24,7 +24,8 @@ module.exports = function sendOK (data, options) {
   res.status(200);
 
   // If appropriate, serve data as JSON(P)
-  if (req.wantsJSON) {
+  // If views are disabled, revert to json
+  if (req.wantsJSON || sails.config.hooks.views === false) {
     return res.jsonx(data);
   }
 

--- a/templates/api/responses/serverError.js
+++ b/templates/api/responses/serverError.js
@@ -36,7 +36,8 @@ module.exports = function serverError (data, options) {
   }
 
   // If the user-agent wants JSON, always respond with JSON
-  if (req.wantsJSON) {
+  // If views are disabled, revert to json
+  if (req.wantsJSON || sails.config.hooks.views === false) {
     return res.jsonx(data);
   }
 


### PR DESCRIPTION
This is actually a hotfix for a problem we encountered. We started using sails to act only as a REST API (please don't ask why). When we ripped out the views, tasks and disabled the grunt + views hooks, things stopped working.

When calling a route, we would always get this error:

```
api/responses/ok.js:44
  else return res.guessView({ data: data }, function couldNotGuessView () {
                  ^

TypeError: res.guessView is not a function
```

The hotfix makes sure that if views are disabled, data is immediately returned in JSON and will not make the server crash by attempting to load a view. 