### PR TITLE
fixes object being returned as a string

### DIFF
--- a/templates/api/responses/badRequest.js
+++ b/templates/api/responses/badRequest.js
@@ -48,27 +48,16 @@ module.exports = function badRequest(data, options) {
   // If it was omitted, use an empty object (`{}`)
   options = (typeof options === 'string') ? { view: options } : options || {};
 
-  // Attempt to prettify data for views, if it's a non-error object
-  var viewData = data;
-  if (!(viewData instanceof Error) && 'object' == typeof viewData) {
-    try {
-      viewData = require('util').inspect(data, {depth: null});
-    }
-    catch(e) {
-      viewData = undefined;
-    }
-  }
-
   // If a view was provided in options, serve it.
   // Otherwise try to guess an appropriate view, or if that doesn't
   // work, just send JSON.
   if (options.view) {
-    return res.view(options.view, { data: viewData, title: 'Bad Request' });
+    return res.view(options.view, { data: data, title: 'Bad Request' });
   }
 
   // If no second argument provided, try to serve the implied view,
   // but fall back to sending JSON(P) if no view can be inferred.
-  else return res.guessView({ data: viewData, title: 'Bad Request' }, function couldNotGuessView () {
+  else return res.guessView({ data: data, title: 'Bad Request' }, function couldNotGuessView () {
     return res.jsonx(data);
   });
 

--- a/templates/api/responses/created.js
+++ b/templates/api/responses/created.js
@@ -33,27 +33,16 @@ module.exports = function created (data, options) {
   // If it was omitted, use an empty object (`{}`)
   options = (typeof options === 'string') ? { view: options } : options || {};
 
-  // Attempt to prettify data for views, if it's a non-error object
-  var viewData = data;
-  if (!(viewData instanceof Error) && 'object' == typeof viewData) {
-    try {
-      viewData = require('util').inspect(data, {depth: null});
-    }
-    catch(e) {
-      viewData = undefined;
-    }
-  }
-
   // If a view was provided in options, serve it.
   // Otherwise try to guess an appropriate view, or if that doesn't
   // work, just send JSON.
   if (options.view) {
-    return res.view(options.view, { data: viewData, title: 'Created' });
+    return res.view(options.view, { data: data, title: 'Created' });
   }
 
   // If no second argument provided, try to serve the implied view,
   // but fall back to sending JSON(P) if no view can be inferred.
-  else return res.guessView({ data: viewData, title: 'Created' }, function couldNotGuessView () {
+  else return res.guessView({ data: data, title: 'Created' }, function couldNotGuessView () {
     return res.jsonx(data);
   });
 

--- a/templates/api/responses/forbidden.js
+++ b/templates/api/responses/forbidden.js
@@ -45,27 +45,16 @@ module.exports = function forbidden (data, options) {
   // If it was omitted, use an empty object (`{}`)
   options = (typeof options === 'string') ? { view: options } : options || {};
 
-  // Attempt to prettify data for views, if it's a non-error object
-  var viewData = data;
-  if (!(viewData instanceof Error) && 'object' == typeof viewData) {
-    try {
-      viewData = require('util').inspect(data, {depth: null});
-    }
-    catch(e) {
-      viewData = undefined;
-    }
-  }
-
   // If a view was provided in options, serve it.
   // Otherwise try to guess an appropriate view, or if that doesn't
   // work, just send JSON.
   if (options.view) {
-    return res.view(options.view, { data: viewData, title: 'Forbidden' });
+    return res.view(options.view, { data: data, title: 'Forbidden' });
   }
 
   // If no second argument provided, try to serve the default view,
   // but fall back to sending JSON(P) if any errors occur.
-  else return res.view('403', { data: viewData, title: 'Forbidden' }, function (err, html) {
+  else return res.view('403', { data: data, title: 'Forbidden' }, function (err, html) {
 
     // If a view error occured, fall back to JSON(P).
     if (err) {

--- a/templates/api/responses/notFound.js
+++ b/templates/api/responses/notFound.js
@@ -50,27 +50,16 @@ module.exports = function notFound (data, options) {
   // If it was omitted, use an empty object (`{}`)
   options = (typeof options === 'string') ? { view: options } : options || {};
 
-  // Attempt to prettify data for views, if it's a non-error object
-  var viewData = data;
-  if (!(viewData instanceof Error) && 'object' == typeof viewData) {
-    try {
-      viewData = require('util').inspect(data, {depth: null});
-    }
-    catch(e) {
-      viewData = undefined;
-    }
-  }
-
   // If a view was provided in options, serve it.
   // Otherwise try to guess an appropriate view, or if that doesn't
   // work, just send JSON.
   if (options.view) {
-    return res.view(options.view, { data: viewData, title: 'Not Found' });
+    return res.view(options.view, { data: data, title: 'Not Found' });
   }
 
   // If no second argument provided, try to serve the default view,
   // but fall back to sending JSON(P) if any errors occur.
-  else return res.view('404', { data: viewData, title: 'Not Found' }, function (err, html) {
+  else return res.view('404', { data: data, title: 'Not Found' }, function (err, html) {
 
     // If a view error occured, fall back to JSON(P).
     if (err) {

--- a/templates/api/responses/ok.js
+++ b/templates/api/responses/ok.js
@@ -33,27 +33,16 @@ module.exports = function sendOK (data, options) {
   // If it was omitted, use an empty object (`{}`)
   options = (typeof options === 'string') ? { view: options } : options || {};
 
-  // Attempt to prettify data for views, if it's a non-error object
-  var viewData = data;
-  if (!(viewData instanceof Error) && 'object' == typeof viewData) {
-    try {
-      viewData = require('util').inspect(data, {depth: null});
-    }
-    catch(e) {
-      viewData = undefined;
-    }
-  }
-
   // If a view was provided in options, serve it.
   // Otherwise try to guess an appropriate view, or if that doesn't
   // work, just send JSON.
   if (options.view) {
-    return res.view(options.view, { data: viewData, title: 'OK' });
+    return res.view(options.view, { data: data, title: 'OK' });
   }
 
   // If no second argument provided, try to serve the implied view,
   // but fall back to sending JSON(P) if no view can be inferred.
-  else return res.guessView({ data: viewData, title: 'OK' }, function couldNotGuessView () {
+  else return res.guessView({ data: data, title: 'OK' }, function couldNotGuessView () {
     return res.jsonx(data);
   });
 

--- a/templates/api/responses/serverError.js
+++ b/templates/api/responses/serverError.js
@@ -45,27 +45,16 @@ module.exports = function serverError (data, options) {
   // If it was omitted, use an empty object (`{}`)
   options = (typeof options === 'string') ? { view: options } : options || {};
 
-  // Attempt to prettify data for views, if it's a non-error object
-  var viewData = data;
-  if (!(viewData instanceof Error) && 'object' == typeof viewData) {
-    try {
-      viewData = require('util').inspect(data, {depth: null});
-    }
-    catch(e) {
-      viewData = undefined;
-    }
-  }
-
   // If a view was provided in options, serve it.
   // Otherwise try to guess an appropriate view, or if that doesn't
   // work, just send JSON.
   if (options.view) {
-    return res.view(options.view, { data: viewData, title: 'Server Error' });
+    return res.view(options.view, { data: data, title: 'Server Error' });
   }
 
   // If no second argument provided, try to serve the default view,
   // but fall back to sending JSON(P) if any errors occur.
-  else return res.view('500', { data: viewData, title: 'Server Error' }, function (err, html) {
+  else return res.view('500', { data: data, title: 'Server Error' }, function (err, html) {
 
     // If a view error occured, fall back to JSON(P).
     if (err) {


### PR DESCRIPTION
Previous implementation cast the object as a string to be able to
display it easily in the views, this had the undesired effect of
making blueprints unusable except for debugging / testing purposes.

It is highly likely that views will not display the object as it is now, so additional work should be taken into consideration before merging this.

One quick solution maybe to attach another key to the object which would be a string representation of itself ? Or just having the cast happen in the view ?